### PR TITLE
Cancellation fixes

### DIFF
--- a/packages/contracts/contracts/AztecStreamer.sol
+++ b/packages/contracts/contracts/AztecStreamer.sol
@@ -279,17 +279,20 @@ contract AztecStreamer is ReentrancyGuard {
         // This ensure that it is close to the true time.
         if (msg.sender == stream.sender) {
             // Sender can only cancel from a timestamp which hasn't already passed
+            // unless giving full value of stream to recipient
             require(
                 // solium-disable-next-line security/no-block-members
-                stream.lastWithdrawTime.add(_unclaimedTime) > block.timestamp,
-                "withdraw is greater than allowed"
+                stream.lastWithdrawTime.add(_unclaimedTime) > block.timestamp ||
+                    stream.lastWithdrawTime.add(_unclaimedTime) ==
+                    stream.stopTime,
+                "sender receives too much from cancellation"
             );
         } else if (msg.sender == stream.recipient) {
             // Recipient can only cancel from a timestamp which has already passed
             require(
                 // solium-disable-next-line security/no-block-members
                 stream.lastWithdrawTime.add(_unclaimedTime) < block.timestamp,
-                "withdraw is greater than allowed"
+                "recipient receives too much from cancellation"
             );
         }
 

--- a/packages/react-app/src/components/status.js
+++ b/packages/react-app/src/components/status.js
@@ -15,7 +15,7 @@ import { CopyToClipboard } from 'react-copy-to-clipboard';
 import moment from 'moment';
 import calculateTime from '../utils/time';
 
-import { calculateMaxWithdrawalValue, withdrawFunds } from '../utils/withdrawal';
+import { calculateWithdrawal, withdrawFunds } from '../utils/withdrawal';
 import { cancelStream } from '../utils/cancellation';
 
 const NoteDecoder = ({ render, zkNote, noteHash }) => {
@@ -50,13 +50,13 @@ const StreamDisplay = ({ stream, note, aztec, streamContractInstance, userAddres
   useEffect(() => {
     async function updateMaxWithdrawalValue() {
       const timeBetweenNotes = (stream.stopTime-stream.lastWithdrawTime)/note.value
-      const maxWithdrawalValue = await calculateMaxWithdrawalValue(stream, note.value)
-      setAvailableBalance(Math.max(maxWithdrawalValue, 0))
+      const { withdrawalValue } = await calculateWithdrawal(note.value, stream.lastWithdrawTime, stream.stopTime)
+      setAvailableBalance(Math.max(withdrawalValue, 0))
 
-      if (!maxWithdrawalValue) {
+      if (!withdrawalValue) {
         // If don't have a good max withdrawal value then check again quickly
         timeoutId = setTimeout(updateMaxWithdrawalValue, 1000)
-      } else if (maxWithdrawalValue !== note.value){
+      } else if (withdrawalValue !== note.value){
         // If stream is not complete then recheck when a new note should be available
         timeoutId = setTimeout(updateMaxWithdrawalValue, timeBetweenNotes/2 * 1000)
       }

--- a/packages/react-app/src/components/status.js
+++ b/packages/react-app/src/components/status.js
@@ -112,7 +112,7 @@ const StreamDisplay = ({ stream, note, aztec, streamContractInstance, userAddres
         <LinearProgress variant="determinate" value={withdrawPercentage} color="secondary" />
         Withdrawn: {withdrawPercentage}%
       </Grid>
-      {role === "recipient" && 
+      {role === "recipient" ?
         <>
           <Grid item>
             {`${availableBalance}/${note.value} ${stream.zkAsset.symbol}`} available to withdraw
@@ -134,6 +134,23 @@ const StreamDisplay = ({ stream, note, aztec, streamContractInstance, userAddres
                 onClick={() => withdrawFunds(aztec, streamContractInstance, stream.id, userAddress)}
                 >
                 Withdraw
+              </Button>
+            </Grid>
+          </Grid>
+        </>
+      :
+        <>
+          <Grid item>
+            {`${availableBalance}/${note.value} ${stream.zkAsset.symbol}`} streamed to recipient
+          </Grid>
+          <Grid item container justify="flex-end">
+            <Grid item>
+              <Button
+                variant="contained"
+                color="primary"
+                onClick={() => cancelStream(aztec, streamContractInstance, stream.id, userAddress)}
+                >
+                Cancel
               </Button>
             </Grid>
           </Grid>

--- a/packages/react-app/src/components/status.js
+++ b/packages/react-app/src/components/status.js
@@ -16,7 +16,7 @@ import moment from 'moment';
 import calculateTime from '../utils/time';
 
 import { calculateMaxWithdrawalValue, withdrawFunds } from '../utils/withdrawal';
-// import { cancelStream } from '../utils/cancellation';
+import { cancelStream } from '../utils/cancellation';
 
 const NoteDecoder = ({ render, zkNote, noteHash }) => {
   const [note, setNote] = useState({});
@@ -117,8 +117,8 @@ const StreamDisplay = ({ stream, note, aztec, streamContractInstance, userAddres
           <Grid item>
             {`${availableBalance}/${note.value} ${stream.zkAsset.symbol}`} available to withdraw
           </Grid>
-          <Grid item container justify="center">
-            {/* <Grid item>
+          <Grid item container justify="space-between">
+            <Grid item>
               <Button
                 variant="contained"
                 color="primary"
@@ -126,7 +126,7 @@ const StreamDisplay = ({ stream, note, aztec, streamContractInstance, userAddres
                 >
                 Cancel
               </Button>
-            </Grid> */}
+            </Grid>
             <Grid item>
               <Button
                 variant="contained"

--- a/packages/react-app/src/components/status.js
+++ b/packages/react-app/src/components/status.js
@@ -51,7 +51,7 @@ const StreamDisplay = ({ stream, note, aztec, streamContractInstance, userAddres
     async function updateMaxWithdrawalValue() {
       const timeBetweenNotes = (stream.stopTime-stream.lastWithdrawTime)/note.value
       const maxWithdrawalValue = await calculateMaxWithdrawalValue(stream, note.value)
-      setAvailableBalance(maxWithdrawalValue)
+      setAvailableBalance(Math.max(maxWithdrawalValue, 0))
 
       if (!maxWithdrawalValue) {
         // If don't have a good max withdrawal value then check again quickly

--- a/packages/react-app/src/utils/cancellation.js
+++ b/packages/react-app/src/utils/cancellation.js
@@ -6,6 +6,8 @@ const BUFFER_SECONDS = 120
 export async function cancelStream(aztec, streamContractInstance, streamId, userAddress) {
   const streamObj = await streamContractInstance.methods.getStream(streamId).call();
 
+  const note = await aztec.zkNote(streamObj.currentBalance)
+
   // If stream sender is cancelling the stream then they need to cancel
   // at a timestamp AFTER which the transaction is included in a block.
   // We then add a buffer of 2 minutes to the time which they try to cancel at.
@@ -15,7 +17,7 @@ export async function cancelStream(aztec, streamContractInstance, streamId, user
   const {
     withdrawalValue,
     withdrawalDuration
-  } = await calculateWithdrawal(streamObj, aztec, bufferSeconds)
+  } = await calculateWithdrawal(note.value, streamObj.lastWithdrawTime, streamObj.stopTime, bufferSeconds)
 
   const { proof1, proof2 } = await buildProofs(aztec, streamContractInstance.options.address, streamObj, withdrawalValue);
 

--- a/packages/react-app/src/utils/cancellation.js
+++ b/packages/react-app/src/utils/cancellation.js
@@ -1,15 +1,21 @@
 import { calculateWithdrawal } from './withdrawal';
 import { buildProofs } from './proofs/cancellationProof';
 
+const BUFFER_SECONDS = 120
 
 export async function cancelStream(aztec, streamContractInstance, streamId, userAddress) {
   const streamObj = await streamContractInstance.methods.getStream(streamId).call();
 
-  // Calculate what value of the stream is redeemable
+  // If stream sender is cancelling the stream then they need to cancel
+  // at a timestamp AFTER which the transaction is included in a block.
+  // We then add a buffer of 2 minutes to the time which they try to cancel at.
+  const bufferSeconds = userAddress === streamObj.sender ? BUFFER_SECONDS : 0
+  
+  // Calculate a valid timestamp to cancel stream at
   const {
     withdrawalValue,
     withdrawalDuration
-  } = await calculateWithdrawal(streamObj, aztec)
+  } = await calculateWithdrawal(streamObj, aztec, bufferSeconds)
 
   const { proof1, proof2 } = await buildProofs(aztec, streamContractInstance.options.address, streamObj, withdrawalValue);
 

--- a/packages/react-app/src/utils/proofs/cancellationProof.js
+++ b/packages/react-app/src/utils/proofs/cancellationProof.js
@@ -11,6 +11,7 @@ export async function buildProofs(aztec, streamContractAddress, streamObj, withd
     streamContractAddress,
     inputNotes[0],
     outputNotes[0],
+    streamObj.sender,
     aztec,
   );
 

--- a/packages/react-app/src/utils/proofs/proofs.js
+++ b/packages/react-app/src/utils/proofs/proofs.js
@@ -40,6 +40,7 @@ export async function buildJoinSplitProof(
   streamContractAddress,
   streamNote,
   withdrawPaymentNote,
+  changeNoteOwner,
   aztec,
 ) {
   const { sender, recipient } = stream;
@@ -53,7 +54,7 @@ export async function buildJoinSplitProof(
     changeValue,
     [{ address: payer.address, linkedPublicKey: payer.linkedPublicKey },
       { address: payee.address, linkedPublicKey: payee.linkedPublicKey }],
-    streamContractAddress,
+    changeNoteOwner
   );
 
   const proofData = new aztec.JoinSplitProof(

--- a/packages/react-app/src/utils/proofs/withdrawalProof.js
+++ b/packages/react-app/src/utils/proofs/withdrawalProof.js
@@ -12,6 +12,7 @@ export async function buildProofs(aztec, streamContractAddress, streamObj, withd
     streamContractAddress,
     inputNotes[0],
     outputNotes[0],
+    streamContractAddress,
     aztec,
   );
 


### PR DESCRIPTION
**features**
- Stream senders can now cancel streams (including a completed stream on behalf of the recipient)

**fixes**
- Calculations on withdrawal/cancellation durations are more robust, to ensure that they always fall on an integer.

closes #24 