### PR TITLE
switch to buidlerEVM for testing

### DIFF
--- a/packages/contracts/.waffle.json
+++ b/packages/contracts/.waffle.json
@@ -1,3 +1,0 @@
-{
-    "compilerVersion": "0.5.15"
-}

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -21,7 +21,7 @@
         "deploy": "buidler run scripts/deploy.js",
         "export": "buidler export",
         "has:changed": "bash ../monorepo-scripts/ci/hasChanged.sh contracts",
-        "test": "waffle .waffle.json && mocha test/runTests.js --timeout 5000",
+        "test": "buidler test test/runTests.js",
         "lint:js": "eslint --config .eslintrc.js ./scripts ./test"
     },
     "files": [

--- a/packages/contracts/test/NoteStream/cancelStream.js
+++ b/packages/contracts/test/NoteStream/cancelStream.js
@@ -1,9 +1,6 @@
+const { waffle } = require('@nomiclabs/buidler');
 const { use, expect } = require('chai');
-const {
-    solidity,
-    MockProvider,
-    createFixtureLoader,
-} = require('ethereum-waffle');
+const { solidity, createFixtureLoader } = require('ethereum-waffle');
 const { bigNumberify, Interface } = require('ethers/utils');
 
 const { devConstants, mochaContexts } = require('@notestream/dev-utils');
@@ -28,7 +25,7 @@ const {
 
 use(solidity);
 
-const provider = new MockProvider();
+const { provider } = waffle;
 const [sender, recipient, attacker] = provider.getWallets();
 const loadFixture = createFixtureLoader(provider, [sender, recipient]);
 

--- a/packages/contracts/test/NoteStream/constructor.js
+++ b/packages/contracts/test/NoteStream/constructor.js
@@ -1,5 +1,6 @@
+const { waffle } = require('@nomiclabs/buidler');
 const { use, expect } = require('chai');
-const { solidity, MockProvider, deployContract } = require('ethereum-waffle');
+const { solidity, deployContract } = require('ethereum-waffle');
 
 const { devConstants } = require('@notestream/dev-utils');
 const NoteStream = require('../../build/NoteStream.json');
@@ -10,7 +11,7 @@ use(solidity);
 
 // eslint-disable-next-line no-undef
 describe('NoteStream - constructor', function () {
-    const provider = new MockProvider();
+    const { provider } = waffle;
     const [deployer] = provider.getWallets();
 
     it('reverts when the ACE contract is the zero address', async function () {

--- a/packages/contracts/test/NoteStream/createStream.js
+++ b/packages/contracts/test/NoteStream/createStream.js
@@ -1,10 +1,7 @@
 // const { devConstants } = require("@notestream/dev-utils");
+const { waffle } = require('@nomiclabs/buidler');
 const { use, expect } = require('chai');
-const {
-    solidity,
-    MockProvider,
-    createFixtureLoader,
-} = require('ethereum-waffle');
+const { solidity, createFixtureLoader } = require('ethereum-waffle');
 const { bigNumberify, Interface } = require('ethers/utils');
 
 const { devConstants } = require('@notestream/dev-utils');
@@ -25,7 +22,7 @@ use(solidity);
 
 // eslint-disable-next-line no-undef
 describe('NoteStream - createStream', function () {
-    const provider = new MockProvider();
+    const { provider } = waffle;
     const [sender, recipient] = provider.getWallets();
     const loadFixture = createFixtureLoader(provider, [sender, recipient]);
 

--- a/packages/contracts/test/NoteStream/getStream.js
+++ b/packages/contracts/test/NoteStream/getStream.js
@@ -1,10 +1,7 @@
 // const { devConstants } = require("@notestream/dev-utils");
+const { waffle } = require('@nomiclabs/buidler');
 const { use, expect } = require('chai');
-const {
-    solidity,
-    MockProvider,
-    createFixtureLoader,
-} = require('ethereum-waffle');
+const { solidity, createFixtureLoader } = require('ethereum-waffle');
 const { bigNumberify } = require('ethers/utils');
 
 const { noteStreamFixture } = require('../fixtures');
@@ -13,7 +10,7 @@ use(solidity);
 
 // eslint-disable-next-line no-undef
 describe('NoteStream - getStream', function () {
-    const provider = new MockProvider();
+    const { provider } = waffle;
     const [sender, recipient] = provider.getWallets();
     const loadFixture = createFixtureLoader(provider, [sender, recipient]);
 

--- a/packages/contracts/test/NoteStream/withdrawFromStream.js
+++ b/packages/contracts/test/NoteStream/withdrawFromStream.js
@@ -1,3 +1,4 @@
+const { waffle } = require('@nomiclabs/buidler');
 const { use, expect } = require('chai');
 const {
     solidity,
@@ -29,7 +30,7 @@ const {
 use(solidity);
 
 function runTests() {
-    const provider = new MockProvider();
+    const { provider } = waffle;
     const [sender, recipient] = provider.getWallets();
     const loadFixture = createFixtureLoader(provider, [sender, recipient]);
 

--- a/packages/contracts/test/StreamUtilities/getRatio.js
+++ b/packages/contracts/test/StreamUtilities/getRatio.js
@@ -1,15 +1,12 @@
+const { waffle } = require('@nomiclabs/buidler');
 const { use } = require('chai');
-const {
-    solidity,
-    MockProvider,
-    createFixtureLoader,
-} = require('ethereum-waffle');
+const { solidity, createFixtureLoader } = require('ethereum-waffle');
 const { StreamUtilitiesFixture } = require('../fixtures');
 
 use(solidity);
 
 describe('StreamUtilities - getRatio', function () {
-    const provider = new MockProvider();
+    const { provider } = waffle;
     const [sender, recipient] = provider.getWallets();
     const loadFixture = createFixtureLoader(provider, [sender, recipient]);
 

--- a/packages/contracts/test/StreamUtilities/processCancellation.js
+++ b/packages/contracts/test/StreamUtilities/processCancellation.js
@@ -1,15 +1,12 @@
+const { waffle } = require('@nomiclabs/buidler');
 const { use } = require('chai');
-const {
-    solidity,
-    MockProvider,
-    createFixtureLoader,
-} = require('ethereum-waffle');
+const { solidity, createFixtureLoader } = require('ethereum-waffle');
 const { StreamUtilitiesFixture } = require('../fixtures');
 
 use(solidity);
 
 describe('StreamUtilities - processCancellation', function () {
-    const provider = new MockProvider();
+    const { provider } = waffle;
     const [sender, recipient] = provider.getWallets();
     const loadFixture = createFixtureLoader(provider, [sender, recipient]);
 

--- a/packages/contracts/test/StreamUtilities/processWithdrawal.js
+++ b/packages/contracts/test/StreamUtilities/processWithdrawal.js
@@ -1,15 +1,12 @@
+const { waffle } = require('@nomiclabs/buidler');
 const { use } = require('chai');
-const {
-    solidity,
-    MockProvider,
-    createFixtureLoader,
-} = require('ethereum-waffle');
+const { solidity, createFixtureLoader } = require('ethereum-waffle');
 const { StreamUtilitiesFixture } = require('../fixtures');
 
 use(solidity);
 
 describe('StreamUtilities - processWithdrawal', function () {
-    const provider = new MockProvider();
+    const { provider } = waffle;
     const [sender, recipient] = provider.getWallets();
     const loadFixture = createFixtureLoader(provider, [sender, recipient]);
 

--- a/packages/contracts/test/StreamUtilities/validateJoinSplitProof.js
+++ b/packages/contracts/test/StreamUtilities/validateJoinSplitProof.js
@@ -1,15 +1,12 @@
+const { waffle } = require('@nomiclabs/buidler');
 const { use } = require('chai');
-const {
-    solidity,
-    MockProvider,
-    createFixtureLoader,
-} = require('ethereum-waffle');
+const { solidity, createFixtureLoader } = require('ethereum-waffle');
 const { StreamUtilitiesFixture } = require('../fixtures');
 
 use(solidity);
 
 describe('StreamUtilities - validateJoinSplitProof', function () {
-    const provider = new MockProvider();
+    const { provider } = waffle;
     const [sender, recipient] = provider.getWallets();
     const loadFixture = createFixtureLoader(provider, [sender, recipient]);
 

--- a/packages/contracts/test/StreamUtilities/validateRatioProof.js
+++ b/packages/contracts/test/StreamUtilities/validateRatioProof.js
@@ -1,15 +1,12 @@
+const { waffle } = require('@nomiclabs/buidler');
 const { use } = require('chai');
-const {
-    solidity,
-    MockProvider,
-    createFixtureLoader,
-} = require('ethereum-waffle');
+const { solidity, createFixtureLoader } = require('ethereum-waffle');
 const { StreamUtilitiesFixture } = require('../fixtures');
 
 use(solidity);
 
 describe('StreamUtilities - validateRatioProof', function () {
-    const provider = new MockProvider();
+    const { provider } = waffle;
     const [sender, recipient] = provider.getWallets();
     const loadFixture = createFixtureLoader(provider, [sender, recipient]);
 

--- a/packages/dev-utils/src/mochaContexts.js
+++ b/packages/dev-utils/src/mochaContexts.js
@@ -14,9 +14,11 @@ function contextForSpecificTime(
   functions,
 ) {
   const now = bigNumberify(moment().format('X'));
+  let snapshot;
 
   describe(contextText, function () {
     beforeEach(async function () {
+      snapshot = await traveler.takeSnapshot(provider);
       await traveler.advanceBlockAndSetTime(
         provider,
         now.add(timeDuration.toString()).toNumber(),
@@ -26,7 +28,7 @@ function contextForSpecificTime(
     functions();
 
     afterEach(async function () {
-      await traveler.advanceBlockAndSetTime(provider, now.toNumber());
+      await traveler.revertToSnapshot(provider, snapshot);
     });
   });
 }


### PR DESCRIPTION
BuilderEvm was failing on reverting the block timestamps in the mocha contexts. Properly using snapshots has fixed this.